### PR TITLE
Update SQL-ConfigureNetworkAdapters.ps1

### DIFF
--- a/Ch03/Ch03/SQL-ConfigureNetworkAdapters.ps1
+++ b/Ch03/Ch03/SQL-ConfigureNetworkAdapters.ps1
@@ -7,4 +7,4 @@ $adapter = Get-NetAdapter "Ethernet"
 $adapter | Set-NetIPAddress -Dhcp Disabled
 $adapter | New-NetIPAddress -AddressFamily IPv4 -IPAddress 192.168.5.1 -PrefixLength 24 -Type Unicast
 Rename-NetAdapter -Name "Ethernet" -NewName "Heartbeat"
-Set-DnsClient -RegisterThisConnectionAddresss $false -InterfaceAlias “Heartbeat”
+Set-DnsClient -RegisterThisConnectionsAddress $false -InterfaceAlias â€œHeartbeatâ€


### PR DESCRIPTION
-RegisterThisConnectionAddress is missing an s and contains an additional s at the end.

get-help set-dnsclient

NAME
    Set-DnsClient

SYNTAX
    Set-DnsClient [-InterfaceAlias] <string[]> [-ConnectionSpecificSuffix <string>] [-RegisterThisConnectionsAddress <bool>] [-UseSuffixWhenRegistering <bool>] [-ResetConnectionSpecificSuffix] [-CimSession <CimSession[]>]
    [-ThrottleLimit <int>] [-AsJob] [-PassThru] [-WhatIf] [-Confirm]  [<CommonParameters>]

    Set-DnsClient -InterfaceIndex <uint32[]> [-ConnectionSpecificSuffix <string>] [-RegisterThisConnectionsAddress <bool>] [-UseSuffixWhenRegistering <bool>] [-ResetConnectionSpecificSuffix] [-CimSession <CimSession[]>] [-ThrottleLimit
    <int>] [-AsJob] [-PassThru] [-WhatIf] [-Confirm]  [<CommonParameters>]

    Set-DnsClient -InputObject <CimInstance#MSFT_DNSClient[]> [-ConnectionSpecificSuffix <string>] [-RegisterThisConnectionsAddress <bool>] [-UseSuffixWhenRegistering <bool>] [-ResetConnectionSpecificSuffix] [-CimSession
    <CimSession[]>] [-ThrottleLimit <int>] [-AsJob] [-PassThru] [-WhatIf] [-Confirm]  [<CommonParameters>]


ALIASES
    None


REMARKS
    Get-Help cannot find the Help files for this cmdlet on this computer. It is displaying only partial help.
        -- To download and install Help files for the module that includes this cmdlet, use Update-Help.